### PR TITLE
Credit for the Template10  package

### DIFF
--- a/docs/Template10Example.md
+++ b/docs/Template10Example.md
@@ -1,0 +1,5 @@
+An simple example application using the Template10 package initially built and maintained by Jerry Nixon of Microsoft but with support and work across many people and departments in Microsoft. This is available as a NuGet package via tha Extensions Manager in Visual Studio with support and documentation here: http://aka.ms/Template10.
+The repository is here: https://github.com/Windows-XAML/Template10.
+Jerry Nixon is here on GitHub: https://github.com/JerryNixon. He's here too: http://jerrynixon.com/.
+The package was put together to support the training and productivity of developers new to building applications targetting Windows 10.
+See training material here: https://mva.microsoft.com/en-US/training-courses/getting-started-with-template-10-16336

--- a/docs/Template10Example.md
+++ b/docs/Template10Example.md
@@ -1,5 +1,6 @@
-An simple example application using the Template10 package initially built and maintained by Jerry Nixon of Microsoft but with support and work across many people and departments in Microsoft. This is available as a NuGet package via tha Extensions Manager in Visual Studio with support and documentation here: http://aka.ms/Template10.
-The repository is here: https://github.com/Windows-XAML/Template10.
-Jerry Nixon is here on GitHub: https://github.com/JerryNixon. He's here too: http://jerrynixon.com/.
+An simple example application using the Template10 package developed, built, and maintained by Jerry Nixon of Microsoft  with support and work across many indivduals and departments in Microsoft.
 The package was put together to support the training and productivity of developers new to building applications targetting Windows 10.
 See training material here: https://mva.microsoft.com/en-US/training-courses/getting-started-with-template-10-16336
+It is available as a NuGet package via tha Extensions Manager in Visual Studio with support and documentation here: http://aka.ms/Template10.
+The repository is here: https://github.com/Windows-XAML/Template10.
+Jerry Nixon is here on GitHub: https://github.com/JerryNixon. He blogs here too: http://jerrynixon.com/.


### PR DESCRIPTION
Including supporting links to explore Template10 and its use. Note that the Template10 package itself is published under the Apache Licence. An application that links to Template10 is not considered a Derivative Work.
